### PR TITLE
Request spec HTTP helpers, fixed vnd accept header, rails 4.2 friendly

### DIFF
--- a/lib/openstax/api/constraints.rb
+++ b/lib/openstax/api/constraints.rb
@@ -9,7 +9,7 @@ module OpenStax
       end
 
       def api_accept_header
-        "application/vnd.openstax.#{OSU::SITE_NAME}.#{@version.to_s}"
+        "application/vnd.openstax.#{@version.to_s}"
       end
       
       def matches?(req)

--- a/lib/openstax/api/engine.rb
+++ b/lib/openstax/api/engine.rb
@@ -1,4 +1,5 @@
 require 'doorkeeper'
+require 'responders'
 require 'roar-rails'
 require 'exception_notification'
 require 'openstax_utilities'

--- a/lib/openstax/api/rspec_helpers.rb
+++ b/lib/openstax/api/rspec_helpers.rb
@@ -90,7 +90,10 @@ module OpenStax
       def request_spec_api_request(type, route, token=nil, args={})
         http_header = {}
         http_header['HTTP_AUTHORIZATION'] = "Bearer #{token.token}" if token.present?
-        http_header['HTTP_ACCEPT'] = "application/vnd.openstax.v1"
+
+        version_string = self.class.metadata[:version].try(:to_s)
+        raise ArgumentError, "Top-level 'describe' metadata must include a value for ':version'" if version_string.nil?
+        http_header['HTTP_ACCEPT'] = "application/vnd.openstax.#{version_string}"
 
         send(type, route, {format: :json}, http_header)
       end

--- a/openstax_api.gemspec
+++ b/openstax_api.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'exception_notification', '>= 4.0'
   s.add_dependency 'openstax_utilities', '>= 4.2.0'
   s.add_dependency 'lev', '>= 1.0.0'
+  s.add_dependency 'responders'
 
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails'

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = false
+  config.serve_static_files = false
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files  = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.

--- a/spec/lib/openstax/api/constraints_spec.rb
+++ b/spec/lib/openstax/api/constraints_spec.rb
@@ -9,14 +9,14 @@ module OpenStax
 
         it 'matches if version is correct in the accept headers' do
           allow(req).to receive(:headers).and_return({
-            'Accept' => 'application/vnd.openstax.dummy.v1'
+            'Accept' => 'application/vnd.openstax.v1'
           })
           expect(constraints.matches? req).to eq true
         end
 
         it 'does not match if version is incorrect in the accept headers' do
           allow(req).to receive(:headers).and_return({
-            'Accept' => 'application/vnd.openstax.dummy.v2'
+            'Accept' => 'application/vnd.openstax.v2'
           })
           expect(constraints.matches? req).to eq false
         end
@@ -43,13 +43,13 @@ module OpenStax
 
         it 'matches if version is correct in the accept headers or if default' do
           allow(req).to receive(:headers).and_return({
-            'Accept' => 'application/vnd.openstax.dummy.v1'
+            'Accept' => 'application/vnd.openstax.v1'
           })
           expect(constraints.matches? req).to eq true
           expect(constraints_2.matches? req).to eq true
 
           allow(req).to receive(:headers).and_return({
-            'Accept' => 'application/vnd.openstax.dummy.v2'
+            'Accept' => 'application/vnd.openstax.v2'
           })
           expect(constraints.matches? req).to eq false
           expect(constraints_2.matches? req).to eq true
@@ -57,7 +57,7 @@ module OpenStax
 
         it 'matches if version is invalid' do
           allow(req).to receive(:headers).and_return({
-            'Accept' => 'application/vnd.openstax.dummy.v3'
+            'Accept' => 'application/vnd.openstax.v3'
           })
           expect(constraints.matches? req).to eq false
           expect(constraints_2.matches? req).to eq true


### PR DESCRIPTION
@Dantemss please review

Now you can use `api_get` and its friends from a controller or request spec and it'll figure out which is the case and make the right call.  

Also, expected vnd accept header is now `vnd.openstax.v1` or other version.  Wasn't previously checking for the correct string and was just falling back on default.