### PR TITLE
Allow CORS in API's

### DIFF
--- a/app/controllers/openstax/api/v1/api_controller.rb
+++ b/app/controllers/openstax/api/v1/api_controller.rb
@@ -22,8 +22,9 @@ module OpenStax
 
         # Except for users logged in via a cookie, we can disable CSRF protection and enable CORS
         skip_before_filter :verify_authenticity_token, unless: :session_user?
-        before_filter :set_cors_preflight_headers, unless: :session_user?
-        after_filter :set_cors_headers, unless: :session_user?
+        skip_before_filter :verify_authenticity_token, only: :options
+        before_filter :set_cors_preflight_headers, only: :options
+        after_filter :set_cors_headers
 
         # Keep old current_user method so we can use it
         alias_method :current_session_user, OpenStax::Api.configuration.current_user_method
@@ -42,6 +43,10 @@ module OpenStax
 
         def current_human_user
           current_api_user.human_user
+        end
+
+        def options
+          head :ok
         end
 
         protected
@@ -68,13 +73,9 @@ module OpenStax
         end
 
         def set_cors_preflight_headers
-          if request.method == 'OPTIONS'
-            headers['Access-Control-Allow-Origin'] = '*'
-            headers['Access-Control-Allow-Methods'] = 'GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS'
-            headers['Access-Control-Max-Age'] = '1728000'
-
-            render :text => '', :content_type => 'text/plain'
-          end
+          headers['Access-Control-Allow-Origin'] = '*'
+          headers['Access-Control-Allow-Methods'] = 'GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS'
+          headers['Access-Control-Max-Age'] = '86400'
         end
 
         def set_cors_headers

--- a/lib/openstax/api/routing_mapper_includes.rb
+++ b/lib/openstax/api/routing_mapper_includes.rb
@@ -7,18 +7,16 @@ module OpenStax
         api_namespace = (options.delete(:namespace) || 'api').to_s
         routing_error_app = options.delete(:routing_error_app) || \
                               OpenStax::Api.configuration.routing_error_app
-        constraints = Constraints.new(version: version,
-                                      default: options.delete(:default))
+        constraints = Constraints.new(version: version, default: options.delete(:default))
 
         namespace api_namespace, defaults: {format: 'json'}.merge(options) do
-          scope(except: [:new, :edit],
-                module: version,
-                constraints: constraints) do
-            get '/', to: '/apipie/apipies#index', defaults: {format: 'html', version: version.to_s}
+          scope(except: [:new, :edit], module: version, constraints: constraints) do
+            root to: '/apipie/apipies#index', defaults: {format: 'html', version: version.to_s}
 
             yield
 
-            match '/*other', via: [:get, :post, :put, :patch, :delete], to: routing_error_app
+            match '/*options', via: [:options], to: '/openstax/api/v1/api#options'
+            match '/*other', via: [:all], to: routing_error_app
           end
         end
       end
@@ -26,5 +24,4 @@ module OpenStax
   end
 end
 
-ActionDispatch::Routing::Mapper.send :include,
-                                     OpenStax::Api::RoutingMapperIncludes
+ActionDispatch::Routing::Mapper.send :include, OpenStax::Api::RoutingMapperIncludes

--- a/spec/controllers/openstax/api/v1/api_controller_spec.rb
+++ b/spec/controllers/openstax/api/v1/api_controller_spec.rb
@@ -116,6 +116,7 @@ module OpenStax
           it 'sets the CORS headers for anonymous users' do
             get 'dummy'
             expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
+            expect(response.headers['Access-Control-Allow-Credentials']).to be_nil
           end
 
           it 'sets the CORS headers for token users' do
@@ -123,12 +124,14 @@ module OpenStax
             @request.headers['Authorization'] = "Bearer #{token}"
             get 'dummy'
             expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
+            expect(response.headers['Access-Control-Allow-Credentials']).to be_nil
           end
 
-          it 'does not set the CORS headers for session users' do
+          it 'sets the CORS headers for session users (the browser should block the request due to no Access-Control-Allow-Credentials header)' do
             @controller.present_user = user
             get 'dummy'
-            expect(response.headers['Access-Control-Allow-Origin']).to be_nil
+            expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
+            expect(response.headers['Access-Control-Allow-Credentials']).to be_nil
           end
         end
 


### PR DESCRIPTION
It seems to be safe to enable CORS in our API's as long as we don't specify the `Access-Control-Allow-Credentials` header, as browsers should not send cookies with requests in that case.