### PR TITLE
Use .find vs .where for loading user records

### DIFF
--- a/app/models/openstax/api/api_user.rb
+++ b/app/models/openstax/api/api_user.rb
@@ -35,7 +35,7 @@ module OpenStax
         # If not, we're in case #1 above and the User should be
         # retrieved from the non_doorkeeper_user_proc.
         @user ||= @doorkeeper_token ? \
-                    USER_CLASS.find(id: @doorkeeper_token.try(:resource_owner_id)) : \
+                    USER_CLASS.find_by(id: @doorkeeper_token.try(:resource_owner_id)) : \
                     @non_doorkeeper_user_proc.call
       end
 

--- a/app/models/openstax/api/api_user.rb
+++ b/app/models/openstax/api/api_user.rb
@@ -34,8 +34,8 @@ module OpenStax
         # If we have a doorkeeper_token, derive the User from it.
         # If not, we're in case #1 above and the User should be
         # retrieved from the non_doorkeeper_user_proc.
-        @user ||= @doorkeeper_token ? USER_CLASS.where(
-                    :id => @doorkeeper_token.try(:resource_owner_id)).first : \
+        @user ||= @doorkeeper_token ? \
+                    USER_CLASS.find(id: @doorkeeper_token.try(:resource_owner_id)) : \
                     @non_doorkeeper_user_proc.call
       end
 

--- a/lib/openstax/api/version.rb
+++ b/lib/openstax/api/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Api
-    VERSION = "5.5.5"
+    VERSION = "5.5.6"
   end
 end


### PR DESCRIPTION
`.where` requires chaining a `.first` which is difficult to mock with a PORO like the `User::User` in tutor-server.