### PR TITLE
Add Authorization to list of allowed headers

### DIFF
--- a/app/controllers/openstax/api/v1/api_controller.rb
+++ b/app/controllers/openstax/api/v1/api_controller.rb
@@ -73,14 +73,14 @@ module OpenStax
         end
 
         def set_cors_preflight_headers
-          headers['Access-Control-Allow-Origin'] = '*'
+          headers['Access-Control-Allow-Origin'] = request.headers["HTTP_ORIGIN"]
           headers['Access-Control-Allow-Methods'] = 'GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS'
           headers['Access-Control-Allow-Headers'] = 'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Token, Authorization'
           headers['Access-Control-Max-Age'] = '86400'
         end
 
         def set_cors_headers
-          headers['Access-Control-Allow-Origin'] = '*'
+          headers['Access-Control-Allow-Origin'] = request.headers["HTTP_ORIGIN"]
         end
 
       end

--- a/app/controllers/openstax/api/v1/api_controller.rb
+++ b/app/controllers/openstax/api/v1/api_controller.rb
@@ -73,14 +73,23 @@ module OpenStax
         end
 
         def set_cors_preflight_headers
-          headers['Access-Control-Allow-Origin'] = request.headers["HTTP_ORIGIN"]
+          headers['Access-Control-Allow-Origin'] = validated_cors_origin
           headers['Access-Control-Allow-Methods'] = 'GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS'
           headers['Access-Control-Allow-Headers'] = 'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Token, Authorization'
           headers['Access-Control-Max-Age'] = '86400'
         end
 
         def set_cors_headers
-          headers['Access-Control-Allow-Origin'] = request.headers["HTTP_ORIGIN"]
+          headers['Access-Control-Allow-Origin'] = validated_cors_origin
+        end
+
+        def validated_cors_origin
+          if OpenStax::Api.configuration.validate_cors_origin &&
+             OpenStax::Api.configuration.validate_cors_origin[ request ]
+            request.headers["HTTP_ORIGIN"]
+          else
+            '' # an empty string will disallow any access
+          end
         end
 
       end

--- a/app/controllers/openstax/api/v1/api_controller.rb
+++ b/app/controllers/openstax/api/v1/api_controller.rb
@@ -3,7 +3,7 @@ module OpenStax
     module V1
 
       class ApiController < ActionController::Base
-  
+
         include ::Roar::Rails::ControllerAdditions
         include OpenStax::Api::Roar
         include OpenStax::Api::Apipie
@@ -75,7 +75,7 @@ module OpenStax
         def set_cors_preflight_headers
           headers['Access-Control-Allow-Origin'] = '*'
           headers['Access-Control-Allow-Methods'] = 'GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS'
-          headers['Access-Control-Allow-Headers'] = 'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Token'
+          headers['Access-Control-Allow-Headers'] = 'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Token, Authorization'
           headers['Access-Control-Max-Age'] = '86400'
         end
 

--- a/lib/openstax_api.rb
+++ b/lib/openstax_api.rb
@@ -33,12 +33,15 @@ module OpenStax
       #
       # routing_error_app is a Rack application that responds to routing errors for the API
       #
+      # validate_cors_origin is a Proc that is called with the reqested origin for CORS requests.
+      # The proc should return true/false to indicate the validity of the request's origin
       class Configuration
         attr_accessor :user_class_name
         attr_accessor :current_user_method
         attr_accessor :routing_error_app
-        
-        def initialize      
+        attr_accessor :validate_cors_origin
+
+        def initialize
           @user_class_name = 'User'
           @current_user_method = 'current_user'
           @routing_error_app = lambda { |env|


### PR DESCRIPTION
Since that's where doorkeeper will look for the bearer token.

For token based auth the header is: `Authorization: Bearer <token>`

https://github.com/doorkeeper-gem/doorkeeper/wiki/Client-Credentials-flow

Needed for https://github.com/openstax/tutor-server/pull/765