### PR TITLE
Add route for replying to OPTIONS requests

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,8 @@
+OpenStax::Api::Engine.routes.draw do
+
+  # respond to a CORS OPTIONS request.
+  # The origin of the request is validated using the
+  # configuration setting `validate_cors_origin`
+  match "/*", to: "api#options", via: [:options]
+
+end


### PR DESCRIPTION
This sets up a single route for the engine so it can be mounted and respond to `OPTIONS` requests.

Browsers check CORS requests in two different ways.  For GET (which is supposed to be idempotent), the request is made and headers checked afterwards.  An after/before filter is enough to handle that.

For POST/PUT/DELETE, a preflight-request is made with type OPTIONS is made.  That needs a route and headers set on it because otherwise the following "real"  POST/PUT/DELETE will never occur.

With this we can mount the engine like: 
`  mount OpenStax::Api::Engine, at: '/'`

I've done so to test course registration on https://github.com/openstax/concept-coach/pull/9 

Is needed for https://github.com/openstax/concept-coach/pull/9 so it can send a POST to the course registration endpoint