### PR TITLE
autoload representers in production

### DIFF
--- a/lib/openstax/api/engine.rb
+++ b/lib/openstax/api/engine.rb
@@ -13,6 +13,8 @@ module OpenStax
     class Engine < ::Rails::Engine
       isolate_namespace OpenStax::Api
 
+      config.autoload_paths += Dir[config.root.join('app', 'representers', '{**}')]
+
       config.generators do |g|
         g.test_framework      :rspec,        fixture: false
         g.fixture_replacement :factory_girl, dir: 'spec/factories'

--- a/lib/openstax/api/version.rb
+++ b/lib/openstax/api/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Api
-    VERSION = "8.2.0"
+    VERSION = "8.2.1"
   end
 end


### PR DESCRIPTION
Previously running `RAILS_ENV=production bundle exec rails console` on the `spec/dummy` app inside `accounts-rails` raised exceptions about not being aware of `OpenStax::Api::V1`.  

With this change it can be found.