### PR TITLE
A couple of small fixes

### DIFF
--- a/lib/openstax/api/rspec_helpers.rb
+++ b/lib/openstax/api/rspec_helpers.rb
@@ -71,9 +71,10 @@ module OpenStax
         # be a URL fragment string -- in such a case, prepend "/api"
         # to the front of the URL as a convenience to callers
 
-        if action.is_a? String
-          action = "/#{action}" if !action.starts_with?("/")
-          action = "/api#{action}" if !action.starts_with?("/api/")
+        action = action.to_s unless is_a_controller_spec?
+        if action.is_a?(String) && !action.include?('://')
+          action = "/#{action}" if !action.starts_with?('/')
+          action = "/api#{action}" if !action.starts_with?('/api/')
         end
 
         send type, action, args

--- a/lib/openstax/api/version.rb
+++ b/lib/openstax/api/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Api
-    VERSION = '9.0.0'
+    VERSION = '9.0.1'
   end
 end


### PR DESCRIPTION
- Fix 404 errors with api_get etc in request specs with absolute urls
- standard_search now always returns `200 OK` (previously it would return `201 CREATED` for a request like `POST /api/exercises/search`)
- Version bump