### PR TITLE
Fix rspec test helpers

### DIFF
--- a/lib/openstax/api/rspec_helpers.rb
+++ b/lib/openstax/api/rspec_helpers.rb
@@ -77,7 +77,7 @@ module OpenStax
           action = "/api#{action}" if !action.starts_with?('/api/')
         end
 
-        send type, action, args
+        send type, action, **args
       end
 
       private

--- a/lib/openstax/api/version.rb
+++ b/lib/openstax/api/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Api
-    VERSION = '9.6.0'
+    VERSION = '9.6.1'
   end
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -9,6 +9,7 @@ Bundler.require(*Rails.groups)
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
+    config.load_defaults 7.1
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
Required in ruby 3, otherwise we get an ArgumentError for incorrect number of arguments.